### PR TITLE
Improve Nix code and add a home-manager module

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,37 @@ cargo install hyprscratch
 ```
 paru -S hyprscratch
 ```
+### Nix:
+```nix
+# flake.nix
+inputs = {
+  hyprscratch = {
+    url = "github:sashetophizika/hyprscratch";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+};
+```
+```nix
+# home.nix
+{inputs, pkgs, ...}: {
+  home.packages = [inputs.hyprscratch.packages.${pkgs.system}.default];
+
+  # or
+
+  imports = [inputs.hyprscratch.homeModules.default];
+  programs.hyprscratch = {
+    enable = true;
+    settings = {
+      btop = {
+        class = "btop";
+        command = "kitty --title btop -e btop";
+        rules = "size 85% 85%";
+        options = "cover persist sticky";
+      };
+    };
+  };
+}
+```
 
 ## Usage
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,21 @@
-{ pkgs ? import <nixpkgs> { } }:
-
-pkgs.rustPlatform.buildRustPackage rec {
-  doCheck = false;
+{
+  lib,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage {
   pname = "hyprscratch";
   version = "0.6.2";
-  cargoLock.lockFile = ./Cargo.lock;
-  src = pkgs.lib.cleanSource ./.;
-}
 
+  src = lib.cleanSource ./.;
+
+  cargoLock.lockFile = ./Cargo.lock;
+
+  doCheck = false;
+
+  meta = {
+    description = "Improved scratchpad functionality for Hyprland";
+    homepage = "https://github.com/sashetophizika/hyprscratch";
+    license = lib.licenses.mit;
+    mainProgram = "hyprscratch";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,12 @@
   in {
     packages = forAllSystems (system: {
       default = self.packages.${system}.hyprscratch;
-      hyprscratch = pkgsFor.${system}.callPackage ./. {};
+      hyprscratch = pkgsFor.${system}.callPackage ./nix {};
     });
+
+    homeModules = {
+      default = self.homeModules.hyprscratch;
+      hyprscratch = import ./nix/hm.nix self;
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,21 @@
 {
   description = "Improved scratchpad functionality for Hyprland";
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
   };
-  outputs = { self, nixpkgs }:
-    let
-      supportedSystems = [ "x86_64-linux" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      pkgsFor = nixpkgs.legacyPackages;
-    in {
-      packages = forAllSystems (system: {
-        default = pkgsFor.${system}.callPackage ./. { };
-      });
-    };
+
+  outputs = {
+    self,
+    nixpkgs,
+  }: let
+    supportedSystems = ["x86_64-linux"];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    pkgsFor = nixpkgs.legacyPackages;
+  in {
+    packages = forAllSystems (system: {
+      default = self.packages.${system}.hyprscratch;
+      hyprscratch = pkgsFor.${system}.callPackage ./. {};
+    });
+  };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,9 +6,9 @@ rustPlatform.buildRustPackage {
   pname = "hyprscratch";
   version = "0.6.2";
 
-  src = lib.cleanSource ./.;
+  src = lib.cleanSource ../.;
 
-  cargoLock.lockFile = ./Cargo.lock;
+  cargoLock.lockFile = ../Cargo.lock;
 
   doCheck = false;
 

--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -1,0 +1,89 @@
+self: {
+  config,
+  pkgs,
+  lib,
+  ...
+}: let
+  inherit (lib.modules) mkIf;
+  inherit (lib.options) mkOption mkEnableOption literalExpression;
+  inherit (lib.hm.generators) toHyprconf;
+  inherit (lib.meta) getExe;
+  inherit
+    (lib.types)
+    package
+    either
+    str
+    attrsOf
+    ;
+
+  cfg = config.programs.hyprscratch;
+in {
+  options.programs.hyprscratch = {
+    enable = mkEnableOption "hyprscratch";
+
+    package = mkOption {
+      type = package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      defaultText = literalExpression ''
+        hyprscratch.packages.''${pkgs.stdenv.hostPlatform.system}.default
+      '';
+      description = ''
+        Hyprscratch package to use. Defaults to the one provided by the flake.
+      '';
+    };
+
+    settings = mkOption {
+      type = attrsOf (either str (attrsOf str));
+      default = {};
+      description = ''
+        Hyprscratch configuration written in Nix.
+      '';
+      example = literalExpression ''
+        {
+          # Optional globals that apply to all scratchpads
+          daemon_options = "clean";
+          global_options = "special";
+          global_rules = "size 90% 90%";
+
+          name = {
+              # Mandatory fields
+              command = "command";
+
+              # At least one is mandatory, title takes priority
+              title = "title";
+              class = "class";
+
+              # Optional fields
+              options = "option1 option2 option3";
+              rules = "rule1;rule2;rule3";
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [cfg.package];
+
+    systemd.user.services.hyprscratch = {
+      Install = {
+        WantedBy = ["default.target"];
+      };
+
+      Unit = {
+        Description = "Hyprscratch: Improved scratchpad functionality for Hyprland";
+      };
+
+      Service = {
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        ExecStart = "${getExe cfg.package} init";
+      };
+    };
+
+    xdg.configFile."hypr/hyprscratch.conf" = mkIf (cfg.settings != {}) {
+      text = toHyprconf {attrs = cfg.settings;};
+    };
+  };
+}


### PR DESCRIPTION
- Formatted with Alejandra
- Added a second package output named "hyprscratch"
- Added a basic Home Manager module that starts hyprscratch using a systemd service and allows for configuring it through Nix.
- Moved the derivation and home module in a "nix" directory
- Added install instructions for Nix